### PR TITLE
Nucleo 3 - CS and RST pins can now be defined in Platformio.ini

### DIFF
--- a/Inc/w5x00_spi.h
+++ b/Inc/w5x00_spi.h
@@ -12,19 +12,12 @@
  * Macros
  * ----------------------------------------------------------------------------------------------------
  */
-/* SPI */
-#define SPI_PORT                1 // GPIOB, SCK_PIN = 3, MISO_PIN = 4, MOSI_PIN = 5  probably needs fixing
-
-#define SPI_CS_PORT             GPIOB //CS_JOG_SW
-#define SPI_CS_PIN              GPIO_PIN_6
-// unsure if these 2 pins are needed, i havent been using them. -cakeslob
-//#define SPI_IRQ_PORT            GPIOC //PRU_RESET
-//#define SPI_IRQ_PIN             GPIO_PIN_3
-#define SPI_RST_PORT            GPIOB // TXD_INT
-#define SPI_RST_PIN             GPIO_PIN_5
-
 /* Use SPI DMA */
-#define USE_SPI_DMA // if you want to use SPI DMA, uncomment.
+#define USE_SPI_DMA 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * ----------------------------------------------------------------------------------------------------
@@ -181,5 +174,9 @@ void network_initialize(wiz_NetInfo net_info);
  *  \param net_info network information.
  */
 void print_network_information(wiz_NetInfo net_info);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _W5X00_SPI_H_ */

--- a/LinuxCNC_Configs/uFlexiNet/config_blackpill_ss.txt
+++ b/LinuxCNC_Configs/uFlexiNet/config_blackpill_ss.txt
@@ -99,7 +99,7 @@
 	{
 	"Thread": "Servo",
 	"Type": "Digital Pin",
-		"Comment":			"OUT1,
+		"Comment":			"OUT1",
 		"Pin":				"PB_1",
 		"Mode":				"Output",
 		"Data Bit":			1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Stepgen, blink and digital io are the only modules supported at the moment. 
 
-Default config that loads on startup is an led blink module on PC13
+
 
 Configs are loaded via tftp , refer to the remora documents for this process
 https://remora-docs.readthedocs.io/en/latest/firmware/ethernet-config.html
@@ -15,10 +15,10 @@ Dont know how to use serial monitor.
 # W5500 connection
 
 
- - PA12 SPI CS
- - PB13 SCK
- - PB14  MISO
- - PB15 MOSI
+ - PB6 SPI CS
+ - PA5 SCK
+ - PA6  MISO
+ - PA7 MOSI
 
 
 # Boards

--- a/Src/main_init.c
+++ b/Src/main_init.c
@@ -28,7 +28,15 @@
 static void SystemClock_Config (void);
 static void MX_GPIO_Init (void);
 static void MX_DMA_Init (void);
+static void MX_USART3_UART_Init(void);
 
+<<<<<<< HEAD
+=======
+#ifdef NUCLEO_F446
+UART_HandleTypeDef huart3;
+#endif
+
+>>>>>>> d4e220b (Enabled printf output on NucleoF446RE board, works on UART3 as is the only port available on Flexihal design.)
 int main_init(void)
 {
     /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
@@ -50,6 +58,10 @@ int main_init(void)
     /* Initialize all configured peripherals */
     MX_GPIO_Init();
     MX_DMA_Init();
+
+    #ifdef NUCLEO_F446
+        MX_USART3_UART_Init();  // If using the same pinout as the Flexihal, the Nucleo only has one workable UART port for debug info. Other boards may have more options. 
+    #endif
 
     uint32_t latency;
     RCC_ClkInitTypeDef clock_cfg;
@@ -448,6 +460,22 @@ static void MX_GPIO_Init(void)
 #ifdef GPIOH
   __HAL_RCC_GPIOH_CLK_ENABLE();
 #endif
+}
+
+static void MX_USART3_UART_Init(void)
+{
+    huart3.Instance = USART3;
+    huart3.Init.BaudRate = 115200;
+    huart3.Init.WordLength = UART_WORDLENGTH_8B;
+    huart3.Init.StopBits = UART_STOPBITS_1;
+    huart3.Init.Parity = UART_PARITY_NONE;
+    huart3.Init.Mode = UART_MODE_TX_RX;
+    huart3.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+    huart3.Init.OverSampling = UART_OVERSAMPLING_16;
+    if (HAL_UART_Init(&huart3) != HAL_OK)
+    {
+      Error_Handler();
+    }
 }
 
 static void MX_DMA_Init (void)

--- a/Src/main_init.c
+++ b/Src/main_init.c
@@ -30,13 +30,10 @@ static void MX_GPIO_Init (void);
 static void MX_DMA_Init (void);
 static void MX_USART3_UART_Init(void);
 
-<<<<<<< HEAD
-=======
 #ifdef NUCLEO_F446
 UART_HandleTypeDef huart3;
 #endif
 
->>>>>>> d4e220b (Enabled printf output on NucleoF446RE board, works on UART3 as is the only port available on Flexihal design.)
 int main_init(void)
 {
     /* Reset of all peripherals, Initializes the Flash interface and the Systick. */

--- a/Src/stm32f4xx_hal_msp.c
+++ b/Src/stm32f4xx_hal_msp.c
@@ -80,7 +80,65 @@ void HAL_MspInit(void)
 }
 
 /* USER CODE BEGIN 1 */
+#ifdef NUCLEO_F446
+/**
+  * @brief UART MSP Initialization
+  * This function configures the hardware resources used in this example
+  * @param huart: UART handle pointer
+  * @retval None
+  */
+void HAL_UART_MspInit(UART_HandleTypeDef* huart)
+{
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
 
+    if(huart->Instance==USART3)
+    {
+        __HAL_RCC_USART3_CLK_ENABLE();
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /**USART3 GPIO Configuration
+        PC5     ------> USART3_RX
+        PC10     ------> USART3_TX
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_5|GPIO_PIN_10;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF7_USART3;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+    }
+}
+
+/**
+  * @brief UART MSP De-Initialization
+  * This function freeze the hardware resources used in this example
+  * @param huart: UART handle pointer
+  * @retval None
+  */
+void HAL_UART_MspDeInit(UART_HandleTypeDef* huart)
+{
+    if(huart->Instance==USART3)
+    {
+        /* Peripheral clock disable */
+        __HAL_RCC_USART3_CLK_DISABLE();
+
+        /**USART3 GPIO Configuration
+        PC5     ------> USART3_RX
+        PC10     ------> USART3_TX
+        */
+        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_5|GPIO_PIN_10);
+    }
+}
+
+/* 
+Project uses NewLib Nano for C-Standard library, however the printf function wasn't ported over. 
+Unsure of performance cost, perhaps best if we implement a debug flag so as to disable this. 
+Or just refactor the code base to directly transmit to UART */
+
+int _write(int file, char *ptr, int len) {
+    HAL_UART_Transmit(&huart3, (uint8_t*) ptr, len, HAL_MAX_DELAY);
+    return len;
+}
+#endif
 /* USER CODE END 1 */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/libraries/ioLibrary_Driver/Ethernet/wizchip_conf.c
+++ b/libraries/ioLibrary_Driver/Ethernet/wizchip_conf.c
@@ -248,7 +248,7 @@ void reg_wizchip_bus_cbfunc(iodata_t(*bus_rb)(uint32_t addr), void (*bus_wb)(uin
    }
 }
 
-void reg_wizchip_spi_cbfunc(uint8_t (*spi_rb)(void), void (*spi_wb)(uint8_t wb))
+void reg_wizchip_spi_cbfunc(uint8_t (*spi_rb)(void), uint8_t (*spi_wb)(uint8_t wb))
 {
    while(!(WIZCHIP.if_mode & _WIZCHIP_IO_MODE_SPI_));
    

--- a/libraries/ioLibrary_Driver/Ethernet/wizchip_conf.h
+++ b/libraries/ioLibrary_Driver/Ethernet/wizchip_conf.h
@@ -492,7 +492,7 @@ void reg_wizchip_bus_cbfunc(iodata_t (*bus_rb)(uint32_t addr), void (*bus_wb)(ui
  *or register your functions.
  *@note If you do not describe or register, null function is called.
  */
-void reg_wizchip_spi_cbfunc(uint8_t (*spi_rb)(void), void (*spi_wb)(uint8_t wb));
+void reg_wizchip_spi_cbfunc(uint8_t (*spi_rb)(void), uint8_t (*spi_wb)(uint8_t wb));
 
 /**
  *@brief Registers call back function for SPI interface.

--- a/platformio.ini
+++ b/platformio.ini
@@ -118,9 +118,10 @@ board_build.ldscript = STM32F446RETX_FLASH.ld
 build_flags = 
 	${common.build_flags}
 	-D SPI_PORT=1
-	#-D SPI1_ALT=1
 	-D NUCLEO_F446=1
 	-D SOCAT_RS485=0 #enable 2nd UDP port for RS485 exchange
+	-D WIZ_CS_PORT_AND_PIN="\"PB_06\""
+	-D WIZ_RST_PORT_AND_PIN="\"PB_05\""
 lib_deps = ${common.lib_deps}
 lib_extra_dirs = ${common.lib_extra_dirs}
 upload_protocol = stlink


### PR DESCRIPTION
Hey mate,

I spent some time on a new implementation of the W5x00 code to enable configuring the SPI CS and Reset pins from platformio.ini. 

Rather than just enable this by hacking it in, I rerouted the pin.cpp driver as a way of abstracting all of the hardware specific stuff so theoretically this becomes agnostic. Doing this meant some of the Wiznet code needed to be converted to C++ which broke a few things in the library, some callbacks had some funny mangling which have been fixed also. A few new warnings but no errors that I know of.

I've tested this and it works on my Nucleo board. Provided you aren't trying to use pins that are set up other peripherals or the JSON config it should work fine. 

Setting the pins up is pretty simple, just add build flags into each of the envs platformio.ini as demonstrated under [env:nucleo446re], example:
	-D WIZ_CS_PORT_AND_PIN="\"PB_06\""
	-D WIZ_RST_PORT_AND_PIN="\"PB_05\""
	
Let me know if you run into any issues. If you think any of the other ports of Remora need this, let me know and I can open separate pull requests. 

I didn't know how to open a PR on just my specific commit, feel free to ignore the others as they may not be relevant to your fork. The one you're after is Commit b8f4e46 